### PR TITLE
Fix import statement and update labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,7 @@ configuration:
   - changed-files:
       - any-glob-to-any-file: ".editorconfig"
       - any-glob-to-any-file: ".gitignore"
+      - any-glob-to-any-file: ".prettierignore"
       - any-glob-to-any-file: "commitlint.config.js"
       - any-glob-to-any-file: "cspell.json"
       - any-glob-to-any-file: "cspell.txt"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { helloWorld } from "../index";
+import { helloWorld } from "../index.js";
 
 /**
  * This is the entry point of the CLI


### PR DESCRIPTION
Update the import statement in the CLI entry point to include the file extension and add `.prettierignore` to the labeler configuration.