### PR TITLE
Update commit message prefixes from chore to build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(composer): [skip ci]"
+      prefix: "build(composer): [skip ci]"
     reviewers:
       - "iamsenthilprabu"
     labels:
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(npm): [skip ci]"
+      prefix: "build(npm): [skip ci]"
     reviewers:
       - "iamsenthilprabu"
     labels:
@@ -42,7 +42,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(actions): [skip ci]"
+      prefix: "build(actions): [skip ci]"
     reviewers:
       - "iamsenthilprabu"
     labels:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,6 +10,7 @@ const length = {
 };
 
 const commitTypes = [
+  "build",
   "feat",
   "fix",
   "docs",

--- a/release.config.js
+++ b/release.config.js
@@ -8,7 +8,7 @@ export default {
         preset: "conventionalcommits",
         releaseRules: [
           {
-            type: "deps",
+            type: "build",
             release: "patch",
           },
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration to standardize commit classifications for build-related changes.
  - Refined release management settings so that build updates now trigger patch releases consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->